### PR TITLE
Fixing an XML builder bug

### DIFF
--- a/api.js
+++ b/api.js
@@ -86,6 +86,7 @@ LgTvApi.prototype.takeScreenShot = function () {
 LgTvApi.prototype.sendXMLRequest = function (path, params) {
     return new Promise((resolve, reject) => {
         let uri = "http://" + this.host + ":" + this.port + path;
+        if(params.command) params.command = { value: params.command.value, name: params.command.name };
         let options = {
             headers: {
                 "Content-Type": "application/atom+xml",


### PR DESCRIPTION
When i tried to proceed a command, my code output something like this: (I have tried with multiple commands)
```
Error: Invalid character in name
    at XMLStringifier.module.exports.XMLStringifier.assertLegalName
```
I checked the source code and made some changes.
The issue was that the `params` parameter had an array which was used as an object (Like this: `{ command: [ value: 21, name: 'HandleKeyInput' ] }`)

This is probably not the best way to fix this, but it does.